### PR TITLE
Document 'options' param of ssh_authorized_key

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -92,7 +92,17 @@ Default value: absent
 ##### `options`
 
 Key options; see sshd(8) for possible values. Multiple values
-should be specified as an array.
+should be specified as an array. For example, you could use the
+following to install a SSH CA that allows someone with the
+'superuser' principal to log in as root
+
+    ssh_authorized_key { 'Company SSH CA':
+      ensure  => present,
+      user    => 'root',
+      type    => 'ssh-ed25519',
+      key     => 'AAAAC3NzaC[...]CeA5kG',
+      options => [ 'cert-authority', 'principals="superuser"' ],
+    }
 
 #### Parameters
 

--- a/lib/puppet/type/ssh_authorized_key.rb
+++ b/lib/puppet/type/ssh_authorized_key.rb
@@ -107,7 +107,17 @@ module Puppet
 
     newproperty(:options, array_matching: :all) do
       desc "Key options; see sshd(8) for possible values. Multiple values
-        should be specified as an array."
+        should be specified as an array. For example, you could use the
+        following to install a SSH CA that allows someone with the
+        'superuser' principal to log in as root
+
+             ssh_authorized_key { 'Company SSH CA':
+               ensure  => present,
+               user    => 'root',
+               type    => 'ssh-ed25519',
+               key     => 'AAAAC3NzaC[...]CeA5kG',
+               options => [ 'cert-authority', 'principals=\"superuser\"' ],
+             }"
 
       defaultto { :absent }
 


### PR DESCRIPTION
I ended up having to trawl through the source code to figure out how to do this, so
I'm sure that someone ELSE would like to save their time by having it documented!