### PR TITLE
ssh_authorzed_key: Fix invalid 'options' error

### DIFF
--- a/lib/puppet/type/ssh_authorized_key.rb
+++ b/lib/puppet/type/ssh_authorized_key.rb
@@ -115,7 +115,7 @@ module Puppet
         unless value == :absent || value =~ %r{^[-a-z0-9A-Z_]+(?:=\".*?\")?$}
           raise(
             Puppet::Error,
-            _("Option %{value} is not valid. A single option must either be of the form 'option' or 'option=\"value\". Multiple options must be provided as an array") % { value: value },
+            _("Option %{value} is not valid. A single option must either be of the form 'option' or 'option=\"value\"'. Multiple options must be provided as an array") % { value: value },
           )
         end
       end


### PR DESCRIPTION
Prior to this, the example of a valid "options" value for the ssh_authorized_key type was syntactically incorrect; it did not include the closing single quote.

Example of incorrect error message:

```
Error: Parameter options failed on Ssh_authorized_key[testkey]: Option from=foo.com is not valid. A single option must either be of the form 'option' or 'option="value". Multiple options must be provided as an array (file: /tmp/test.pp, line: 5)
```

After this, the error shows the correct syntax for specifying an option:

```
Error: Parameter options failed on Ssh_authorized_key[testkey]: Option from=foo.com is not valid. A single option must either be of the form 'option' or 'option="value"'. Multiple options must be provided as an array (file: /tmp/test.pp, line: 5)
```