### PR TITLE
Do not silently skip unknown OS

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -54,10 +54,7 @@
       ]
     },
     {
-      "operatingsystem": "Darwin",
-      "operatingsystemrelease": [
-        "16"
-      ]
+      "operatingsystem": "Darwin"
     },
     {
       "operatingsystem": "SLES",


### PR DESCRIPTION
I was trying to edit `~/.ssh/known_hosts` and because of this constraint action was just skipping without any logs even in debug mode. I think you should put these version constraints closer to the code they are related to.