### PR TITLE
(MODULES-10671) New SSH key types for OpenSSH 8.2

### DIFF
--- a/lib/puppet/type/ssh_authorized_key.rb
+++ b/lib/puppet/type/ssh_authorized_key.rb
@@ -62,11 +62,14 @@ module Puppet
     newproperty(:type) do
       desc 'The encryption type used.'
 
-      newvalues :'ssh-dss', :'ssh-rsa', :'ecdsa-sha2-nistp256', :'ecdsa-sha2-nistp384', :'ecdsa-sha2-nistp521', :'ssh-ed25519'
+      newvalues :'ssh-dss', :'ssh-rsa', :'ecdsa-sha2-nistp256', :'ecdsa-sha2-nistp384', :'ecdsa-sha2-nistp521', :'ssh-ed25519',
+                :'sk-ecdsa-sha2-nistp256@openssh.com', :'sk-ssh-ed25519@openssh.com'
 
       aliasvalue(:dsa, :'ssh-dss')
       aliasvalue(:ed25519, :'ssh-ed25519')
       aliasvalue(:rsa, :'ssh-rsa')
+      aliasvalue(:'ecdsa-sk', :'sk-ecdsa-sha2-nistp256@openssh.com')
+      aliasvalue(:'ed25519-sk', :'sk-ssh-ed25519@openssh.com')
     end
 
     newproperty(:key) do
@@ -159,7 +162,9 @@ module Puppet
     end
 
     # regular expression suitable for use by a ParsedFile based provider
-    REGEX = %r{^(?:(.+)\s+)?(ssh-dss|ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp256|ecdsa-sha2-nistp384|ecdsa-sha2-nistp521)\s+([^ ]+)\s*(.*)$}
+    REGEX = %r{^(?:(.+)\s+)?(ssh-dss|ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp256|
+            ecdsa-sha2-nistp384|ecdsa-sha2-nistp521|ecdsa-sk|ed25519-sk|
+            sk-ecdsa-sha2-nistp256@openssh.com|sk-ssh-ed25519@openssh.com)\s+([^ ]+)\s*(.*)$}x
     def self.keyline_regex
       REGEX
     end

--- a/lib/puppet/type/sshkey.rb
+++ b/lib/puppet/type/sshkey.rb
@@ -15,7 +15,7 @@ module Puppet
     def self.title_patterns
       [
         [
-          %r{^(.*)@(.*)$},
+          %r{^(.*?)@(.*)$},
           [
             [:name],
             [:type],
@@ -35,11 +35,14 @@ module Puppet
 
       isnamevar
 
-      newvalues :'ssh-dss', :'ssh-ed25519', :'ssh-rsa', :'ecdsa-sha2-nistp256', :'ecdsa-sha2-nistp384', :'ecdsa-sha2-nistp521'
+      newvalues :'ssh-dss', :'ssh-ed25519', :'ssh-rsa', :'ecdsa-sha2-nistp256', :'ecdsa-sha2-nistp384', :'ecdsa-sha2-nistp521',
+                :'sk-ecdsa-sha2-nistp256@openssh.com', :'sk-ssh-ed25519@openssh.com'
 
       aliasvalue(:dsa, :'ssh-dss')
       aliasvalue(:ed25519, :'ssh-ed25519')
       aliasvalue(:rsa, :'ssh-rsa')
+      aliasvalue(:'ecdsa-sk', :'sk-ecdsa-sha2-nistp256@openssh.com')
+      aliasvalue(:'ed25519-sk', :'sk-ssh-ed25519@openssh.com')
     end
 
     newproperty(:key) do

--- a/spec/unit/type/ssh_authorized_key_spec.rb
+++ b/spec/unit/type/ssh_authorized_key_spec.rb
@@ -85,7 +85,9 @@ describe Puppet::Type.type(:ssh_authorized_key), unless: Puppet.features.microso
         :'ecdsa-sha2-nistp256',
         :'ecdsa-sha2-nistp384',
         :'ecdsa-sha2-nistp521',
-        :ed25519, :'ssh-ed25519'
+        :ed25519, :'ssh-ed25519',
+        :'ecdsa-sk', :'sk-ecdsa-sha2-nistp256@openssh.com',
+        :'ed25519-sk', :'sk-ssh-ed25519@openssh.com'
       ].each do |keytype|
         it "supports #{keytype}" do
           described_class.new(name: 'whev', type: keytype, user: 'nobody')
@@ -100,6 +102,16 @@ describe Puppet::Type.type(:ssh_authorized_key), unless: Puppet.features.microso
       it 'aliases :dsa to :ssh-dss' do
         key = described_class.new(name: 'whev', type: :dsa, user: 'nobody')
         expect(key.should(:type)).to eq :'ssh-dss'
+      end
+
+      it 'aliases :ecdsa-sk to :sk-ecdsa-sha2-nistp256@openssh.com' do
+        key = described_class.new(name: 'whev', type: :'ecdsa-sk', user: 'nobody')
+        expect(key.should(:type)).to eq :'sk-ecdsa-sha2-nistp256@openssh.com'
+      end
+
+      it 'aliases :ed25519-sk to :sk-ssh-ed25519@openssh.com' do
+        key = described_class.new(name: 'whev', type: :'ed25519-sk', user: 'nobody')
+        expect(key.should(:type)).to eq :'sk-ssh-ed25519@openssh.com'
       end
 
       it "doesn't support values other than ssh-dss, ssh-rsa, dsa, rsa" do

--- a/spec/unit/type/sshkey_spec.rb
+++ b/spec/unit/type/sshkey_spec.rb
@@ -27,7 +27,9 @@ describe Puppet::Type.type(:sshkey) do
       :'ecdsa-sha2-nistp256',
       :'ecdsa-sha2-nistp384',
       :'ecdsa-sha2-nistp521',
-      :'ssh-ed25519', :ed25519
+      :'ssh-ed25519', :ed25519,
+      :'ecdsa-sk', :'sk-ecdsa-sha2-nistp256@openssh.com',
+      :'ed25519-sk', :'sk-ssh-ed25519@openssh.com'
     ].each do |keytype|
       it "supports #{keytype} as a type value" do
         described_class.new(name: 'foo', type: keytype)
@@ -42,6 +44,16 @@ describe Puppet::Type.type(:sshkey) do
     it 'aliases :dsa to :ssh-dss' do
       key = described_class.new(name: 'foo', type: :dsa)
       expect(key.parameter(:type).value).to eq :'ssh-dss'
+    end
+
+    it 'aliases :ecdsa-sk to :sk-ecdsa-sha2-nistp256@openssh.com' do
+      key = described_class.new(name: 'foo', type: :'ecdsa-sk')
+      expect(key.parameter(:type).value).to eq :'sk-ecdsa-sha2-nistp256@openssh.com'
+    end
+
+    it 'aliases :ed25519-sk to :ssh-dss' do
+      key = described_class.new(name: 'foo', type: :'ed25519-sk')
+      expect(key.parameter(:type).value).to eq :'sk-ssh-ed25519@openssh.com'
     end
 
     it "doesn't support values other than ssh-dss, ssh-rsa, dsa, rsa for type" do


### PR DESCRIPTION
Two new SSH key types were added on OpenSSH 8.2:
sk-ecdsa-sha2-nistp256@openssh.com(alias ecdsa-sk) and
sk-ssh-ed25519@openssh.com(alias ed25519-sk)