### PR TITLE
(MODULES-10827) Exported sshkey already exists error

### DIFF
--- a/lib/puppet/type/sshkey.rb
+++ b/lib/puppet/type/sshkey.rb
@@ -12,6 +12,8 @@ module Puppet
       "#{self[:name]}@#{self[:type]}"
     end
 
+    alias_method :title, :name
+
     def self.parameters_to_include
       [:name, :type]
     end

--- a/spec/unit/type/sshkey_spec.rb
+++ b/spec/unit/type/sshkey_spec.rb
@@ -81,5 +81,10 @@ describe Puppet::Type.type(:sshkey) do
         described_class.new(name: 'host,host.domain,ip')
       }.to raise_error(Puppet::Error, %r{No comma in resourcename})
     end
+
+    it 'aliases :title to :name' do
+      key = described_class.new(name: 'foo', type: :rsa)
+      expect(key.name).to eq key.title
+    end
   end
 end


### PR DESCRIPTION
Using module https://github.com/ghoneycutt/puppet-module-ssh to export
and collect sshkey resources from nodes, an 'already declared' error
appears.

This happened because when the catalog is first converted to resouces,
the sshkey resource is added via
https://github.com/puppetlabs/puppet/blob/main/lib/puppet/resource/catalog.rb#L137,
where 'resource.ref'(https://github.com/puppetlabs/puppet/blob/main/lib/puppet/type.rb#L2548)
uses 'self.title'.
Since self.title goes to the title method defined in type.rb, it will
return a different title than the title method from
https://github.com/puppetlabs/puppetlabs-sshkeys_core/blob/main/lib/puppet/provider/sshkey/parsed.rb#L31.
This mismatch try to add both resource, resulting in the 'already
declared' error.