### PR TITLE
(MODULES-10953) Update metadata.json and pdk version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,6 +77,8 @@ Style/SymbolArray:
   EnforcedStyle: brackets
 RSpec/NamedSubject:
   Enabled: false
+RSpec/SubjectStub:
+  Enabled: false
 Style/Documentation:
   Exclude:
   - lib/puppet/parser/functions/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ end
 
 group :release do
   gem "puppet-blacksmith", '~> 3.4',                                             require: false
-  gem "pdk",                                                                     platforms: [:ruby]
+  gem "pdk", '~> 2.0',                                                           platforms: [:ruby]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/metadata.json
+++ b/metadata.json
@@ -12,78 +12,43 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "CentOS"
     },
     {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "OracleLinux"
     },
     {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "RedHat"
     },
     {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "Scientific"
     },
     {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "8"
-      ]
+      "operatingsystem": "Debian"
     },
     {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "16.04"
-      ]
+      "operatingsystem": "Ubuntu"
     },
     {
-      "operatingsystem": "Fedora",
-      "operatingsystemrelease": [
-        "25"
-      ]
+      "operatingsystem": "Fedora"
     },
     {
-      "operatingsystem": "Darwin",
-      "operatingsystemrelease": [
-        "16"
-      ]
+      "operatingsystem": "Darwin"
     },
     {
-      "operatingsystem": "SLES",
-      "operatingsystemrelease": [
-        "12"
-      ]
+      "operatingsystem": "SLES"
     },
     {
-      "operatingsystem": "Solaris",
-      "operatingsystemrelease": [
-        "11"
-      ]
+      "operatingsystem": "Solaris"
     },
     {
-      "operatingsystem": "windows",
-      "operatingsystemrelease": [
-        "2008 R2",
-        "2012 R2",
-        "10"
-      ]
+      "operatingsystem": "windows"
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "pdk-version": "1.14.0",

--- a/spec/integration/provider/ssh_authorized_key_spec.rb
+++ b/spec/integration/provider/ssh_authorized_key_spec.rb
@@ -49,9 +49,9 @@ describe Puppet::Type.type(:ssh_authorized_key).provider(:parsed), unless: Puppe
   end
 
   before :each do
-    File.stubs(:chown)
-    File.stubs(:chmod)
-    Puppet::Util::SUIDManager.stubs(:asuser).yields
+    allow(File).to receive(:chown)
+    allow(File).to receive(:chmod)
+    allow(Puppet::Util::SUIDManager).to receive(:asuser).and_yield
   end
 
   after :each do
@@ -74,18 +74,18 @@ describe Puppet::Type.type(:ssh_authorized_key).provider(:parsed), unless: Puppe
   end
 
   def run_in_catalog(*resources)
-    Puppet::FileBucket::Dipper.any_instance.stubs(:backup) # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(Puppet::FileBucket::Dipper).to receive(:backup) # rubocop:disable RSpec/AnyInstance
     catalog = Puppet::Resource::Catalog.new
     catalog.host_config = false
     resources.each do |resource|
-      resource.expects(:err).never
+      expect(resource).not_to receive(:err)
       catalog.add_resource(resource)
     end
     catalog.apply
   end
 
   it 'does not complain about empty lines and comments' do
-    described_class.expects(:flush).never
+    expect(described_class).not_to receive(:flush)
     sample = ['', sample_lines[0], '   ', sample_lines[1], '# just a comment', '#and another']
     create_fake_key(:user, sample)
     run_in_catalog(dummy)

--- a/spec/integration/provider/sshkey_spec.rb
+++ b/spec/integration/provider/sshkey_spec.rb
@@ -12,10 +12,9 @@ describe Puppet::Type.type(:sshkey).provider(:parsed), unless: Puppet.features.m
 
   before :each do
     # Don't backup to filebucket
-    Puppet::FileBucket::Dipper.any_instance.stubs(:backup) # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(Puppet::FileBucket::Dipper).to receive(:backup) # rubocop:disable RSpec/AnyInstance
     # We don't want to execute anything
-    described_class.stubs(:filetype)
-                   .returns Puppet::Util::FileType::FileTypeFlat
+    allow(described_class).to receive(:filetype).and_return Puppet::Util::FileType::FileTypeFlat
 
     FileUtils.cp(my_fixture('sample'), sshkey_file)
   end
@@ -188,11 +187,9 @@ describe Puppet::Type.type(:sshkey).provider(:parsed), unless: Puppet.features.m
     it 'fetches an entry from resources' do
       resource_app = Puppet::Application[:resource]
       resource_app.preinit
-      resource_app.command_line
-                  .stubs(:args)
-                  .returns([type_under_test, sshkey_name, "target=#{sshkey_file}"])
+      allow(resource_app.command_line).to receive(:args).and_return([type_under_test, sshkey_name, "target=#{sshkey_file}"])
 
-      resource_app.expects(:puts).with do |args|
+      expect(resource_app).to receive(:puts) do |args|
         expect(args).to match(%r{#{sshkey_name}})
       end
       resource_app.main

--- a/spec/lib/puppet_spec/compiler.rb
+++ b/spec/lib/puppet_spec/compiler.rb
@@ -48,7 +48,7 @@ module PuppetSpec::Compiler
 
   def apply_with_error_check(manifest)
     apply_compiled_manifest(manifest) do |res|
-      res.expects(:err).never
+      expect(res).to receive(:err).never
     end
   end
 

--- a/spec/lib/puppet_spec/files.rb
+++ b/spec/lib/puppet_spec/files.rb
@@ -11,7 +11,7 @@ module PuppetSpec::Files
     until @global_tempfiles.empty?
       path = @global_tempfiles.pop
       begin
-        Dir.unstub(:entries)
+        allow(Dir).to receive(:entries).and_call_original
         FileUtils.rm_rf path, secure: true
       rescue Errno::ENOENT # rubocop:disable Lint/HandleExceptions
         # nothing to do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ default_facts.each do |fact, value|
 end
 
 RSpec.configure do |c|
+  c.mock_with :rspec
   c.default_facts = default_facts
   c.before :each do
     # set to strictest setting for testing

--- a/spec/unit/provider/sshkey/parsed_spec.rb
+++ b/spec/unit/provider/sshkey/parsed_spec.rb
@@ -42,7 +42,7 @@ describe 'sshkey parsed provider' do
     ['sample', 'sample_with_blank_lines'].each do |sample_file|
       let(:fixture) { my_fixture(sample_file) }
 
-      before(:each) { subject.stubs(:default_target).returns(fixture) }
+      before(:each) { allow(subject).to receive(:default_target).and_return(fixture) }
 
       it 'parses to records on prefetch' do
         expect(subject.target_records(fixture)).to be_empty
@@ -72,22 +72,22 @@ describe 'sshkey parsed provider' do
   context 'default ssh_known_hosts target path' do
     ['9.10', '9.11', '10.10'].each do |version|
       it 'is `/etc/ssh_known_hosts` when OSX version 10.10 or older`' do
-        Facter.expects(:value).with(:operatingsystem).returns('Darwin')
-        Facter.expects(:value).with(:macosx_productversion_major).returns(version)
+        expect(Facter).to receive(:value).with(:operatingsystem).and_return('Darwin')
+        expect(Facter).to receive(:value).with(:macosx_productversion_major).and_return(version)
         expect(subject.default_target).to eq('/etc/ssh_known_hosts')
       end
     end
 
     ['10.11', '10.13', '11.0', '11.11'].each do |version|
       it 'is `/etc/ssh/ssh_known_hosts` when OSX version 10.11 or newer`' do
-        Facter.expects(:value).with(:operatingsystem).returns('Darwin')
-        Facter.expects(:value).with(:macosx_productversion_major).returns(version)
+        expect(Facter).to receive(:value).with(:operatingsystem).and_return('Darwin')
+        expect(Facter).to receive(:value).with(:macosx_productversion_major).and_return(version)
         expect(subject.default_target).to eq('/etc/ssh/ssh_known_hosts')
       end
     end
 
     it 'is `/etc/ssh/ssh_known_hosts` on other operating systems' do
-      Facter.expects(:value).with(:operatingsystem).returns('RedHat')
+      expect(Facter).to receive(:value).with(:operatingsystem).and_return('RedHat')
       expect(subject.default_target).to eq('/etc/ssh/ssh_known_hosts')
     end
   end

--- a/spec/unit/type/ssh_authorized_key_spec.rb
+++ b/spec/unit/type/ssh_authorized_key_spec.rb
@@ -4,12 +4,12 @@ describe Puppet::Type.type(:ssh_authorized_key), unless: Puppet.features.microso
   include PuppetSpec::Files
 
   before(:each) do
-    provider_class = stub 'provider_class', name: 'fake', suitable?: true, supports_parameter?: true
-    described_class.stubs(:defaultprovider).returns(provider_class)
-    described_class.stubs(:provider).returns(provider_class)
+    provider_class = class_double('Puppet::Provider::SshAuthorizedKey', name: 'fake', suitable?: true, supports_parameter?: true)
+    allow(described_class).to receive(:defaultprovider).and_return(provider_class)
+    allow(described_class).to receive(:provider).and_return(provider_class)
 
-    provider = stub 'provider', class: provider_class, file_path: make_absolute('/tmp/whatever'), clear: nil
-    provider_class.stubs(:new).returns(provider)
+    provider = instance_double('Puppet::Provider::SshAuthorizedKey', class: provider_class, file_path: make_absolute('/tmp/whatever'), clear: nil)
+    allow(provider_class).to receive(:new).and_return(provider)
   end
 
   it 'has :name as its namevar' do

--- a/spec/unit/type/user_spec.rb
+++ b/spec/unit/type/user_spec.rb
@@ -25,7 +25,7 @@ describe Puppet::Type.type(:user) do
   end
 
   before :each do
-    described_class.stubs(:defaultprovider).returns provider_class
+    allow(described_class).to receive(:defaultprovider).and_return provider_class
   end
 
   describe 'when purging ssh keys' do
@@ -58,7 +58,7 @@ describe Puppet::Type.type(:user) do
     if Puppet.version.start_with?('6')
       context 'with no home directory specified' do
         before(:each) do
-          Dir.stubs(:home).with('a').returns('/home/a')
+          allow(Dir).to receive(:home).with('a').and_return('/home/a')
         end
 
         it 'does accept true' do
@@ -83,7 +83,7 @@ describe Puppet::Type.type(:user) do
       end
 
       before(:each) do
-        Dir.stubs(:home).with('test').returns('/home/test')
+        allow(Dir).to receive(:home).with('test').and_return('/home/test')
       end
 
       let(:paths) do
@@ -91,13 +91,13 @@ describe Puppet::Type.type(:user) do
       end
 
       it 'does not just return from generate' do
-        subject.expects :find_unmanaged_keys
+        expect(subject).to receive(:find_unmanaged_keys)
         subject.generate
       end
 
       it 'checks each keyfile for readability' do
         paths.each do |path|
-          File.expects(:readable?).with(path)
+          expect(File).to receive(:readable?).with(path)
         end
         subject.generate
       end
@@ -111,7 +111,7 @@ describe Puppet::Type.type(:user) do
       end
 
       before(:each) do
-        Dir.stubs(:home).with('test_user_name').returns('/home/test_user_name')
+        allow(Dir).to receive(:home).with('test_user_name').and_return('/home/test_user_name')
       end
 
       context 'when purging is disabled' do


### PR DESCRIPTION
To avoid having to update this everytime we release a new agent platform, it should be enough to specify the supported OS, without specific versions. It is assumed that for each OS in metadata.json, the versions supported are the same as what the agent itself supports.