### PR TITLE
(PUP-11370) Github workflow now uses windows 2019

### DIFF
--- a/.github/workflows/dispatch_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/dispatch_unit_tests_with_nightly_puppet_gem.yaml
@@ -75,7 +75,7 @@ jobs:
     
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
+        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2019' ]
         include:
           - os: 'ubuntu-18.04'
             os_type: 'Linux'
@@ -85,7 +85,7 @@ jobs:
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file_postfix: '-universal-darwin.gem'
-          - os: 'windows-2016'
+          - os: 'windows-2019'
             os_type: 'Windows'
             env_set_cmd: '$env:'
             gem_file_postfix: '-x64-mingw32.gem'

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
+        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2019' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -28,7 +28,7 @@ jobs:
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest-universal-darwin.gem'
-          - os: 'windows-2016'
+          - os: 'windows-2019'
             os_type: 'Windows'
             env_set_cmd: '$env:'
             gem_file: 'puppet-latest-x64-mingw32.gem'

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
+        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2019' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -24,7 +24,7 @@ jobs:
             os_type: 'Linux'
           - os: 'macos-10.15'
             os_type: 'macOS'
-          - os: 'windows-2016'
+          - os: 'windows-2019'
             os_type: 'Windows'
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Upgraded github actions to use windows 2019 instead of windows 2016 as
it will be removed on March 15, 2022.