### PR TITLE
(maint) Adds retry to nighty gem unit tests

### DIFF
--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -45,8 +45,17 @@ jobs:
 
       - name: Install the latest nightly build of puppet${{ matrix.puppet_version }} gem
         run: |
-          curl http://nightlies.puppet.com/downloads/gems/puppet${{ matrix.puppet_version }}-nightly/${{ matrix.gem_file }} --output puppet.gem
-          gem install puppet.gem -N
+          sleep_time=0
+          until [ $sleep_time -ge 15 ]
+          do
+            curl http://nightlies.puppet.com/downloads/gems/puppet${{ matrix.puppet_version }}-nightly/${{ matrix.gem_file }} --output puppet.gem
+            gem install puppet.gem -N && break
+
+            sleep_time=$((sleep_time*2+1))
+            echo "Retrying download and install of gem in $sleep_time seconds..."
+            sleep $sleep_time
+          done
+        shell: bash
 
       - name: Prepare testing environment with bundler
         run: |


### PR DESCRIPTION
We have seen transient failures with this job the last few days, possibly due to the timing of the gem being published. This adds a simple shell loop to retry downloading and installing the nightly gem.