### PR TITLE
(main) Make dispatch workflow parameter mandatory

### DIFF
--- a/.github/workflows/dispatch_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/dispatch_unit_tests_with_nightly_puppet_gem.yaml
@@ -6,6 +6,7 @@ on:
     inputs:
       pa_ref:
         description: 'Puppet Agent SHA to use in this run'
+        required: true
 
 jobs:
   set_output_data:


### PR DESCRIPTION
This makes the `pa_ref` parameter mandatory in the `dispatch_unit_tests_with_nightly_puppet_gem`
workflow to avoid invalid runs
Example of failed run:
https://github.com/puppetlabs/puppetlabs-sshkeys_core/runs/4773665009?check_suite_focus=true