### PR TITLE
(maint) Replace matrix.puppet_version with env.puppet_version

### DIFF
--- a/.github/workflows/dispatch_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/dispatch_unit_tests_with_nightly_puppet_gem.yaml
@@ -106,7 +106,7 @@ jobs:
           sleep_time=0
           until [ $sleep_time -ge 15 ]
           do
-            curl --location http://nightlies.puppet.com/downloads/gems/puppet${{ matrix.puppet_version }}-nightly/${{ matrix.gem_file }} --output puppet.gem
+            curl --location http://nightlies.puppet.com/downloads/gems/puppet${{ env.puppet_version }}-nightly/${{ matrix.gem_file_postfix }} --output puppet.gem
             gem install puppet.gem -N && break
 
             sleep_time=$((sleep_time*2+1))


### PR DESCRIPTION
This commit changes the way we get the `puppet_version` when installing
the latest nightly build of puppet.

`matrix.puppet_version` would return : ` 6.25.1.107.g74406a1 `, which is not a valid gem version