### PR TITLE
(maint) Increase retry time

### DIFF
--- a/.github/workflows/dispatch_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/dispatch_unit_tests_with_nightly_puppet_gem.yaml
@@ -104,7 +104,7 @@ jobs:
       - name: Install the latest nightly build of puppet${{ env.puppet_version }} gem
         run: |
           sleep_time=0
-          until [ $sleep_time -ge 15 ]
+          until [ $sleep_time -ge 511 ]
           do
             curl --location http://nightlies.puppet.com/downloads/gems/puppet${{ env.puppet_version }}-nightly/puppet-${{ needs.set_output_data.outputs.puppet_short_commit }}${{ matrix.gem_file_postfix }} --output puppet.gem
             gem install puppet.gem -N && break


### PR DESCRIPTION
Increased the time for retries because the jenkins job that triggers the
workflow doesn't have the time to ship.