### PR TITLE
(MODULES-11355) Update macOS runners to use more recent macOS version

### DIFF
--- a/.github/workflows/dispatch_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/dispatch_unit_tests_with_nightly_puppet_gem.yaml
@@ -76,13 +76,13 @@ jobs:
     
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2019' ]
+        os: [ 'ubuntu-18.04', 'macos-latest', 'windows-2019' ]
         include:
           - os: 'ubuntu-18.04'
             os_type: 'Linux'
             env_set_cmd: 'export '
             gem_file_postfix: '.gem'
-          - os: 'macos-10.15'
+          - os: 'macos-latest'
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file_postfix: '-universal-darwin.gem'

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2019' ]
+        os: [ 'ubuntu-18.04', 'macos-latest', 'windows-2019' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -24,7 +24,7 @@ jobs:
             os_type: 'Linux'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest.gem'
-          - os: 'macos-10.15'
+          - os: 'macos-latest'
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest-universal-darwin.gem'

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2019' ]
+        os: [ 'ubuntu-18.04', 'macos-latest', 'windows-2019' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -22,7 +22,7 @@ jobs:
 
           - os: 'ubuntu-18.04'
             os_type: 'Linux'
-          - os: 'macos-10.15'
+          - os: 'macos-latest'
             os_type: 'macOS'
           - os: 'windows-2019'
             os_type: 'Windows'


### PR DESCRIPTION
GitHub announced they are deprecating macOS 10.15 runners for GitHub Actions by 12/1/2022. This PR migrates puppetlabs-sshkeys_core's GitHub Actions off of macOS 10.15.