### PR TITLE
metadata: add Windows

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -42,6 +42,9 @@
       "operatingsystem": "Solaris"
     },
     {
+      "operatingsystem": "windows"
+    },
+    {
       "operatingsystem": "Rocky"
     },
     {


### PR DESCRIPTION
This reverts commit c3cf902f2122d4f5715a871ea15d1667f2bbfacf.

I'm using the `sshkey` type on Windows with success.