### PR TITLE
Return true on trusted_path if path is really trusted.

### DIFF
--- a/lib/puppet/provider/ssh_authorized_key/parsed.rb
+++ b/lib/puppet/provider/ssh_authorized_key/parsed.rb
@@ -64,6 +64,7 @@ Puppet::Type.type(:ssh_authorized_key).provide(
       path = path.dirname
     end
     Puppet.debug('Path trusted, writing the file as the current user')
+    return true
   end
 
   def flush


### PR DESCRIPTION
If drop_privileges is set to false (default is true), the trusted_path function does check if the path is trusted or not and returns false if this isn't the case. If this conditional path is not hit, there is no return true, which leaves the state of the function 'nil', thus being false.

This change should account for the true case.