### PR TITLE
(PA-5805) Add Windows support in sshkeys_core 

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -45,6 +45,9 @@
       "operatingsystem": "Rocky"
     },
     {
+      "operatingsystem": "windows"
+    },
+    {
       "operatingsystem": "AlmaLinux"
     },
     {

--- a/spec/acceptance/tests/resource/ssh_authorized_key/destroy_spec.rb
+++ b/spec/acceptance/tests/resource/ssh_authorized_key/destroy_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper_acceptance'
 
 RSpec.context 'ssh_authorized_key: Destroy' do
-  confine :except, platform: ['windows']
-
   let(:auth_keys) { '~/.ssh/authorized_keys' }
   let(:name) { "pl#{rand(999_999).to_i}" }
   let(:custom_key_directory) { "/etc/ssh_authorized_keys_#{name}" }


### PR DESCRIPTION
This commit enables Windows agents in the destroy_spec.rb so Windows agents can be used in sshkeys spec tests.