### PR TITLE
PE-40175

### DIFF
--- a/lib/puppet/type/sshkey.rb
+++ b/lib/puppet/type/sshkey.rb
@@ -52,15 +52,16 @@ module Puppet
     end
 
     newproperty(:key) do
-      desc "The key itself; generally a long string of uuencoded characters. The `key`
-        attribute may not contain whitespace.
+      desc "The key itself; generally a long string of unencoded characters. The `key`
+        attribute may not contain leading or trailing whitespace.
 
         Make sure to omit the following in this attribute (and specify them in
         other attributes):
 
-        * Key headers, such as 'ssh-rsa' --- put these in the `type` attribute.
-        * Key identifiers / comments, such as 'joescomputer.local' --- put these in
-          the `name` attribute/resource title."
+        * Key headers, such as 'ssh-rsa' --- put these in the `type` attribute."
+      validate do |value|
+        raise Puppet::Error, _('Key must contain neither leading nor trailing whitespace: %{value}') % { value: value } if %r{^\s|\s$}.match?(value)
+      end
     end
 
     # FIXME: This should automagically check for aliases to the hosts, just

--- a/spec/unit/type/sshkey_spec.rb
+++ b/spec/unit/type/sshkey_spec.rb
@@ -76,6 +76,12 @@ describe Puppet::Type.type(:sshkey) do
       }.to raise_error(Puppet::Error, %r{cannot include whitespace})
     end
 
+    it "doesn't accept leading or trailing whitespace in the key contents" do
+      expect {
+        described_class.new(name: 'foo', key: ' AAAFA==')
+      }.to raise_error(Puppet::Error, %r{Key must contain neither leading nor trailing whitespace})
+    end
+
     it "doesn't accept aliases in the resourcename" do
       expect {
         described_class.new(name: 'host,host.domain,ip')


### PR DESCRIPTION
Prior to this commit the sshkey type didn't prohibit whitespace in the key property. This change now fails the resource type if a user adds space and adds a spec test