### PR TITLE
Add support for cert-authority

### DIFF
--- a/lib/puppet/provider/sshkey/parsed.rb
+++ b/lib/puppet/provider/sshkey/parsed.rb
@@ -12,14 +12,41 @@ Puppet::Type.type(:sshkey).provide(
 
   record_line :parsed, fields: ['name', 'type', 'key'],
                        post_parse: proc { |hash|
-                                     names = hash[:name].split(',', -1)
-                                     hash[:name] = names.shift
-                                     hash[:host_aliases] = names
+                                     # Check if this is a cert-authority line by looking at the name field
+                                     if hash[:name] && hash[:name] == '@cert-authority'
+                                       # Re-parse the cert-authority format: @cert-authority hostname keytype key
+                                       # The original fields were: name='@cert-authority', type='hostname', key='keytype actualkey'
+                                       hostname = hash[:type]
+                                       keytype_and_key = hash[:key].split(/\s+/, 2)
+                                       if keytype_and_key.length >= 2
+                                         keytype = keytype_and_key[0]
+                                         actual_key = keytype_and_key[1]
+                                         hash[:name] = hostname
+                                         hash[:type] = "@cert-authority #{keytype}"
+                                         hash[:key] = actual_key
+                                       end
+                                     end
+
+                                     # Handle host aliases for all entries
+                                     if hash[:name]
+                                       names = hash[:name].split(',', -1)
+                                       hash[:name] = names.shift
+                                       hash[:host_aliases] = names
+                                     end
                                    },
                        pre_gen: proc { |hash|
                                   if hash[:host_aliases]
                                     hash[:name] = [hash[:name], hash[:host_aliases]].flatten.join(',')
                                     hash.delete(:host_aliases)
+                                  end
+                                  # Handle cert-authority format
+                                  if hash[:type] && hash[:type].to_s.start_with?('@cert-authority ')
+                                    # Extract the key type from '@cert-authority ssh-rsa' format
+                                    key_type = hash[:type].to_s.sub(/^@cert-authority /, '')
+                                    # Reorder fields for cert-authority format: @cert-authority name key_type key
+                                    # We need to restructure to have three fields: name="@cert-authority hostname", type="keytype", key=key
+                                    hash[:name] = "@cert-authority #{hash[:name]}"
+                                    hash[:type] = key_type
                                   end
                                 }
 

--- a/lib/puppet/type/sshkey.rb
+++ b/lib/puppet/type/sshkey.rb
@@ -37,18 +37,30 @@ module Puppet
     end
 
     newparam(:type) do
-      desc 'The encryption type used.  Probably ssh-dss or ssh-rsa.'
+      desc 'The encryption type used.  Probably ssh-dss or ssh-rsa.
+        For certificate authorities, use @cert-authority followed by the key type,
+        e.g., @cert-authority ssh-rsa. This will create an entry in the known_hosts
+        file formatted as "@cert-authority hostname keytype key" which allows SSH
+        to validate host certificates signed by the specified certificate authority.'
 
       isnamevar
 
       newvalues :'ssh-dss', :'ssh-ed25519', :'ssh-rsa', :'ecdsa-sha2-nistp256', :'ecdsa-sha2-nistp384', :'ecdsa-sha2-nistp521',
-                :'sk-ecdsa-sha2-nistp256@openssh.com', :'sk-ssh-ed25519@openssh.com'
+                :'sk-ecdsa-sha2-nistp256@openssh.com', :'sk-ssh-ed25519@openssh.com',
+                :'@cert-authority ssh-dss', :'@cert-authority ssh-ed25519', :'@cert-authority ssh-rsa',
+                :'@cert-authority ecdsa-sha2-nistp256', :'@cert-authority ecdsa-sha2-nistp384', :'@cert-authority ecdsa-sha2-nistp521',
+                :'@cert-authority sk-ecdsa-sha2-nistp256@openssh.com', :'@cert-authority sk-ssh-ed25519@openssh.com'
 
       aliasvalue(:dsa, :'ssh-dss')
       aliasvalue(:ed25519, :'ssh-ed25519')
       aliasvalue(:rsa, :'ssh-rsa')
       aliasvalue(:'ecdsa-sk', :'sk-ecdsa-sha2-nistp256@openssh.com')
       aliasvalue(:'ed25519-sk', :'sk-ssh-ed25519@openssh.com')
+      aliasvalue(:'@cert-authority dsa', :'@cert-authority ssh-dss')
+      aliasvalue(:'@cert-authority ed25519', :'@cert-authority ssh-ed25519')
+      aliasvalue(:'@cert-authority rsa', :'@cert-authority ssh-rsa')
+      aliasvalue(:'@cert-authority ecdsa-sk', :'@cert-authority sk-ecdsa-sha2-nistp256@openssh.com')
+      aliasvalue(:'@cert-authority ed25519-sk', :'@cert-authority sk-ssh-ed25519@openssh.com')
     end
 
     newproperty(:key) do

--- a/spec/unit/provider/sshkey/parsed_spec.rb
+++ b/spec/unit/provider/sshkey/parsed_spec.rb
@@ -38,6 +38,20 @@ describe 'sshkey parsed provider' do
     expect(subject.parse_line('test ssh-rsa ' + key)[:host_aliases]).to eq([])
   end
 
+  it 'parses cert-authority entries correctly' do
+    result = subject.parse_line('@cert-authority *.example.com ssh-rsa ' + key)
+    expect(result[:name]).to eq('*.example.com')
+    expect(result[:type]).to eq('@cert-authority ssh-rsa')
+    expect(result[:key]).to eq(key)
+  end
+
+  it 'parses cert-authority entries with host aliases' do
+    result = subject.parse_line('@cert-authority *.example.com,*.test.com ssh-rsa ' + key)
+    expect(result[:name]).to eq('*.example.com')
+    expect(result[:host_aliases]).to eq(['*.test.com'])
+    expect(result[:type]).to eq('@cert-authority ssh-rsa')
+  end
+
   context 'with the sample file' do
     ['sample', 'sample_with_blank_lines'].each do |sample_file|
       let(:fixture) { my_fixture(sample_file) }

--- a/spec/unit/type/sshkey_spec.rb
+++ b/spec/unit/type/sshkey_spec.rb
@@ -29,7 +29,15 @@ describe Puppet::Type.type(:sshkey) do
       :'ecdsa-sha2-nistp521',
       :'ssh-ed25519', :ed25519,
       :'ecdsa-sk', :'sk-ecdsa-sha2-nistp256@openssh.com',
-      :'ed25519-sk', :'sk-ssh-ed25519@openssh.com'
+      :'ed25519-sk', :'sk-ssh-ed25519@openssh.com',
+      :'@cert-authority ssh-dss', :'@cert-authority dsa',
+      :'@cert-authority ssh-rsa', :'@cert-authority rsa',
+      :'@cert-authority ecdsa-sha2-nistp256',
+      :'@cert-authority ecdsa-sha2-nistp384',
+      :'@cert-authority ecdsa-sha2-nistp521',
+      :'@cert-authority ssh-ed25519', :'@cert-authority ed25519',
+      :'@cert-authority ecdsa-sk', :'@cert-authority sk-ecdsa-sha2-nistp256@openssh.com',
+      :'@cert-authority ed25519-sk', :'@cert-authority sk-ssh-ed25519@openssh.com'
     ].each do |keytype|
       it "supports #{keytype} as a type value" do
         described_class.new(name: 'foo', type: keytype)
@@ -54,6 +62,21 @@ describe Puppet::Type.type(:sshkey) do
     it 'aliases :ed25519-sk to :ssh-dss' do
       key = described_class.new(name: 'foo', type: :'ed25519-sk')
       expect(key.parameter(:type).value).to eq :'sk-ssh-ed25519@openssh.com'
+    end
+
+    it 'aliases :@cert-authority rsa to :@cert-authority ssh-rsa' do
+      key = described_class.new(name: 'foo', type: :'@cert-authority rsa')
+      expect(key.parameter(:type).value).to eq :'@cert-authority ssh-rsa'
+    end
+
+    it 'aliases :@cert-authority dsa to :@cert-authority ssh-dss' do
+      key = described_class.new(name: 'foo', type: :'@cert-authority dsa')
+      expect(key.parameter(:type).value).to eq :'@cert-authority ssh-dss'
+    end
+
+    it 'aliases :@cert-authority ed25519 to :@cert-authority ssh-ed25519' do
+      key = described_class.new(name: 'foo', type: :'@cert-authority ed25519')
+      expect(key.parameter(:type).value).to eq :'@cert-authority ssh-ed25519'
     end
 
     it "doesn't support values other than ssh-dss, ssh-rsa, dsa, rsa for type" do


### PR DESCRIPTION
Add support for `ssh_key` type `cert-authority`

Fixes https://github.com/puppetlabs/puppetlabs-sshkeys_core/issues/89

